### PR TITLE
Avoid type panics

### DIFF
--- a/eapache/eapache.go
+++ b/eapache/eapache.go
@@ -53,10 +53,20 @@ func ConfigGetter(e config.ExtraConfig) interface{} {
 	}
 	cfg := Config{}
 	if v, ok := tmp["error"]; ok {
-		cfg.Error = int(v.(float64))
+		switch i := v.(type) {
+		case int:
+			cfg.Error = i
+		case float64:
+			cfg.Error = int(i)
+		}
 	}
 	if v, ok := tmp["success"]; ok {
-		cfg.Success = int(v.(float64))
+		switch i := v.(type) {
+		case int:
+			cfg.Success = i
+		case float64:
+			cfg.Success = int(i)
+		}
 	}
 	if v, ok := tmp["timeout"]; ok {
 		if d, err := time.ParseDuration(v.(string)); err == nil {

--- a/eapache/proxy/proxy_test.go
+++ b/eapache/proxy/proxy_test.go
@@ -24,8 +24,8 @@ func TestNewMiddleware_multipleNext(t *testing.T) {
 
 func TestNewMiddleware_zeroConfig(t *testing.T) {
 	for _, cfg := range []*config.Backend{
-		&config.Backend{},
-		&config.Backend{ExtraConfig: map[string]interface{}{eapache.Namespace: 42}},
+		{},
+		{ExtraConfig: map[string]interface{}{eapache.Namespace: 42}},
 	} {
 		resp := proxy.Response{}
 		mdw := NewMiddleware(cfg)

--- a/gobreaker/gobreaker.go
+++ b/gobreaker/gobreaker.go
@@ -57,13 +57,28 @@ func ConfigGetter(e config.ExtraConfig) interface{} {
 	}
 	cfg := Config{}
 	if v, ok := tmp["interval"]; ok {
-		cfg.Interval = int(v.(float64))
+		switch i := v.(type) {
+		case int:
+			cfg.Interval = i
+		case float64:
+			cfg.Interval = int(i)
+		}
 	}
 	if v, ok := tmp["timeout"]; ok {
-		cfg.Timeout = int(v.(float64))
+		switch i := v.(type) {
+		case int:
+			cfg.Timeout = i
+		case float64:
+			cfg.Timeout = int(i)
+		}
 	}
 	if v, ok := tmp["maxErrors"]; ok {
-		cfg.MaxErrors = int(v.(float64))
+		switch i := v.(type) {
+		case int:
+			cfg.MaxErrors = i
+		case float64:
+			cfg.MaxErrors = int(i)
+		}
 	}
 	value, ok := tmp["logStatusChange"].(bool)
 	cfg.LogStatusChange = ok && value

--- a/gobreaker/proxy/proxy_test.go
+++ b/gobreaker/proxy/proxy_test.go
@@ -25,8 +25,8 @@ func TestNewMiddleware_multipleNext(t *testing.T) {
 
 func TestNewMiddleware_zeroConfig(t *testing.T) {
 	for _, cfg := range []*config.Backend{
-		&config.Backend{},
-		&config.Backend{ExtraConfig: map[string]interface{}{gcb.Namespace: 42}},
+		{},
+		{ExtraConfig: map[string]interface{}{gcb.Namespace: 42}},
 	} {
 		resp := proxy.Response{}
 		mdw := NewMiddleware(cfg, gologging.MustGetLogger("proxy_test"))


### PR DESCRIPTION
some parsers creates the numerical values for the extra configs as float64 and others as int.